### PR TITLE
#1575: Adds X-Forwarded-Host header and removes Host header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -88,9 +88,9 @@ http {
         location /get_token { include 'nginx-cacheless.conf'; }
 
         location / {
-            proxy_set_header  Host $http_host;
             proxy_set_header  X-Real-IP $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header  X-Forwarded-Host $http_host;
             proxy_set_header  Forwarded "for=$remote_addr;proto=$http_x_forwarded_proto";
 
             proxy_cache_valid 200 302 301  3m;
@@ -136,9 +136,9 @@ http {
         location /get_token { include 'nginx-cacheless.conf'; }
 
         location / {
-            proxy_set_header  Host $http_host;
             proxy_set_header  X-Real-IP $remote_addr;
             proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header  X-Forwarded-Host $http_host;
             proxy_set_header  Forwarded "for=$remote_addr;proto=$http_x_forwarded_proto";
 
             proxy_cache_valid 200 302 301  3m;


### PR DESCRIPTION
connects to NDLANO/Issues#1575
Linkerd service meshet bruker host headeren så da kan komponentene heller bruker `X-Forwarded-Host`.