### PR TITLE
Proxy to statisk

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -95,11 +95,8 @@ http {
             proxy_pass             $sitemap_url;
         }
 
-        location ~* ^/(forlarere.*) {
-            set $bucket_url        'http://statisk.ndla.no.s3.amazonaws.com/$1';
-
-            proxy_cache shared_frontend_cache;
-            proxy_pass             $bucket_url;
+        location ~* ^/(forlarere) {
+            proxy_pass             'http://statisk.ndla.no/$1/';
         }
 
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -95,8 +95,11 @@ http {
             proxy_pass             $sitemap_url;
         }
 
-        location ~* ^/(forlarere) {
-            proxy_pass             'http://statisk.ndla.no/$1/';
+        location ~* ^/(forlarere.*) {
+            set $bucket_url        'http://statisk.ndla.no.s3.amazonaws.com/$1';
+
+            proxy_cache shared_frontend_cache;
+            proxy_pass             $bucket_url;
         }
 
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -95,6 +95,11 @@ http {
             proxy_pass             $sitemap_url;
         }
 
+        location ~* ^/(forlarere) {
+            proxy_pass             'http://statisk.ndla.no/$1/';
+        }
+
+
         location /minndla { include 'nginx-cacheless.conf'; }
         location ~ /[a-z]+/minndla { include 'nginx-cacheless.conf'; }
         location /login { include 'nginx-cacheless.conf'; }


### PR DESCRIPTION
NDLA ønsker at path /forlarere skal vise innholdet på statisk.ndla.no/forlarere. Dette redirecter brukeren til statisk, men det var det beste eg fikk til.