### PR TITLE
Add rss proxy to article-api :^)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM nginx:1.25.3-alpine-slim
 
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY start-nginx.sh /start-nginx.sh
+RUN chmod +x /start-nginx.sh
+
 COPY nginx-caches-default.conf /etc/nginx/
 COPY nginx-caches-prod.conf /etc/nginx/
 COPY nginx-cacheless.conf /etc/nginx/
-
-COPY start-nginx.sh /start-nginx.sh
-
-RUN chmod +x /start-nginx.sh
+COPY nginx.conf /etc/nginx/nginx.conf
 
 CMD ["/start-nginx.sh"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -80,6 +80,7 @@ http {
         access_log /var/log/nginx/access.log;
 
         include '/ndla-frontend-hostname.conf';
+        include '/api-gateway-hostname.conf';
 
         proxy_buffer_size          256k;
         proxy_buffers              4 256k;
@@ -97,6 +98,11 @@ http {
 
         location ~* ^/(forlarere) {
             proxy_pass             'http://statisk.ndla.no/$1/';
+        }
+
+        location ~ /about/(.*)/rss.xml {
+            proxy_set_header    Host   'api-gateway';
+            proxy_pass 'http://$api_gateway/article-api/v2/articles/$1/rss.xml';
         }
 
 

--- a/start-nginx.sh
+++ b/start-nginx.sh
@@ -29,10 +29,12 @@ function setup_frontend_hostnames {
         echo "set \$frontend 'ndla-frontend.default.svc.cluster.local';" > /ndla-frontend-hostname.conf
         echo "set \$frontend 'learningpath-frontend.default.svc.cluster.local';" >> /learningpath-frontend-hostname.conf
         echo "set \$frontend 'listing-frontend.default.svc.cluster.local';" >> /listing-frontend-hostname.conf
+        echo "set \$api_gateway 'api-gateway.default.svc.cluster.local';" > /api-gateway-hostname.conf
     else
         echo "set \$frontend 'ndla-frontend.ndla-local';" > /ndla-frontend-hostname.conf
         echo "set \$frontend 'learningpath-frontend.ndla-local';" >> /learningpath-frontend-hostname.conf
         echo "set \$frontend 'listing-frontend.ndla-local';" >> /listing-frontend-hostname.conf
+        echo "set \$api_gateway 'api-gateway.ndla-local';" > /api-gateway-hostname.conf
     fi
 }
 


### PR DESCRIPTION
Legger til en location blokk som gjør at `https://test.ndla.no/about/utlysninger/rss.xml` blir til routet til endepunktet som returnerer xml for artikkelen i article-api.